### PR TITLE
Update tr() and trl() to not fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,25 @@
 var React = require('react');
 
 module.exports = {
-  
+
   tr() {
-    if(window.tr) {
-      var args = Array.prototype.slice.call(arguments);
-      return React.createElement("span", {
-        dangerouslySetInnerHTML: {
-          __html: window.tr.apply(this, args)
-        } 
-      });
+    var args = Array.prototype.slice.call(arguments);
+    if(!window.trl || !args[0]) {
+      return args[0];
     }
+    return React.createElement("span", {
+      dangerouslySetInnerHTML: {
+        __html: window.tr.apply(this, args)
+      }
+    });
   },
 
   trl() {
-    if(window.trl) {
-      var args = Array.prototype.slice.call(arguments);
-      return window.trl.apply(this, args);
+    var args = Array.prototype.slice.call(arguments);
+    if(!window.trl || !args[0]) {
+      return args[0];
     }
+    return window.trl.apply(this, args);
   }
 
 };


### PR DESCRIPTION
If window.tr/trl isn't there nothing is returned. Less of a case. If arg[0] is undefined, tr()/trl() fails and React will also fail. This just simply return back undefined in case.

Examples `tr(something.undefined)` would fail, now it will skip and continue on.